### PR TITLE
feat: add LiteLLM as AI gateway provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@
 ![Ollama](https://img.shields.io/badge/Ollama-000000?style=for-the-badge&logo=ollama&logoColor=white)
 ![OpenRouter](https://img.shields.io/badge/OpenRouter-6566f1?style=for-the-badge&logo=openrouter&logoColor=white)
 ![ChatGPT](https://img.shields.io/badge/ChatGPT-74aa9c?style=for-the-badge&logo=openai&logoColor=white)
+![LiteLLM](https://img.shields.io/badge/LiteLLM-01B4E4?style=for-the-badge&logo=data:image/svg+xml;base64,&logoColor=white)
 <!-- ![Claude](https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=anthropic&logoColor=white) -->
 </div>
 
@@ -83,6 +84,7 @@ MODES:
     -o  [--ollama]            =  use local models via Ollama (Offline,cloud:online )
     -or [--openrouter]        =  use OpenRouter models (Online)
     -c  [--chatgpt]           =  use OpenAI models (Online)
+    -ll [--litellm]           =  use 100+ providers via LiteLLM (Online)
     --web                     =  AIs official Web-Chat Opener (Online)
     --setup-keys              =  setup API keys for online models
     -u [--update]             =  update KaliGPT to latest version

--- a/agents/litellm_provider.py
+++ b/agents/litellm_provider.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+
+# /agents/litellm_provider.py
+# KaliGPT LiteLLM Agent
+# LiteLLM AI gateway: access 100+ LLM providers via a unified interface
+
+import sys
+import json
+
+from .utils.agent_configs import get_ai_specific_default_model
+from .utils.agent_management import AI_MANAGEMENT_OPTIONS, agent_management
+from .utils.parse_n_print_response import parse_n_print_response
+from .utils.tools import get_tools_info
+from .utils.openai_tool_adapter import openai_tool_adapter
+from .utils.prompts import WEB_BUG_BOUNTY_AGENT as SYSTEM_PROMPT
+
+# ----- Global Variables
+LITELLM_MODEL: str
+TOOLS_INFO = None
+TOOL_FUNCTION_MAP: dict
+
+
+def initialize_agent():
+    global LITELLM_MODEL, TOOLS_INFO, TOOL_FUNCTION_MAP
+
+    try:
+        LITELLM_MODEL = get_ai_specific_default_model("litellm")
+
+        tools = get_tools_info()
+        TOOLS_INFO = [openai_tool_adapter(f) for f in tools]
+        TOOL_FUNCTION_MAP = {func.__name__: func for func in tools} if tools else {}
+
+        if not TOOLS_INFO:
+            print("[!] No external tools loaded.")
+
+    except Exception as e:
+        print(f"Failed to initialize Agent: {e}")
+        sys.exit(1)
+
+
+MAX_TURNS = 6
+
+
+def trim_history(history):
+    system = [m for m in history if m["role"] == "system"]
+    rest = [m for m in history if m["role"] != "system"]
+    return system + rest[-MAX_TURNS * 2:]
+
+
+def execute_tool_calls(tool_calls):
+    tool_messages = []
+
+    for tool_call in tool_calls:
+        func_name = tool_call.function.name
+        call_id = tool_call.id
+
+        try:
+            func_args = json.loads(tool_call.function.arguments)
+            print(f"\n[HackerX Tool Use] name: {func_name}, args: {func_args}")
+        except Exception as e:
+            print(f"[!] Error parsing tool arguments: {e}")
+            func_args = {}
+
+        tool_fn = TOOL_FUNCTION_MAP.get(func_name)
+        if not tool_fn:
+            result = f"Error: Tool '{func_name}' not found"
+        else:
+            try:
+                result = tool_fn(**func_args)
+            except Exception as e:
+                result = f"Tool execution error: {e}"
+
+        tool_messages.append({
+            "role": "tool",
+            "tool_call_id": call_id,
+            "name": func_name,
+            "content": str(result)
+        })
+
+    return tool_messages
+
+
+def ask(prompt, chat_history, tools=None):
+    import litellm
+
+    if tools is None:
+        tools = TOOLS_INFO
+
+    messages = trim_history(chat_history) + [{"role": "user", "content": prompt}]
+
+    try:
+        completion = litellm.completion(
+            model=LITELLM_MODEL,
+            messages=messages,
+            tools=tools,
+            tool_choice="auto" if tools else "none",
+            drop_params=True,
+        )
+
+        response_msg = completion.choices[0].message
+
+        while response_msg.tool_calls:
+            messages.append(response_msg)
+            tool_results = execute_tool_calls(response_msg.tool_calls)
+            messages.extend(tool_results)
+
+            follow_up = litellm.completion(
+                model=LITELLM_MODEL,
+                messages=messages,
+                tools=tools,
+                drop_params=True,
+            )
+            response_msg = follow_up.choices[0].message
+
+        final_text = response_msg.content or ""
+
+        chat_history.append({"role": "user", "content": prompt})
+        chat_history.append({"role": "assistant", "content": final_text})
+
+        return final_text, chat_history
+
+    except Exception as e:
+        error_msg = f"API/Logic Error: {str(e)}"
+        return error_msg, chat_history
+
+
+def main(prompt=None):
+
+    initialize_agent()
+
+    chat_history: list = [{"role": "system", "content": SYSTEM_PROMPT}]
+
+    print(f"㉿ HackerX ( litellm/{LITELLM_MODEL} )")
+
+    while True:
+        try:
+            if prompt is None:
+                prompt = input("\nYou ➤ ")
+
+            if prompt.lower().replace("-", " ").strip() in AI_MANAGEMENT_OPTIONS:
+                agent_management(prompt.lower().replace("-", " ").strip())
+                initialize_agent()
+                prompt = None
+                continue
+
+            response, chat_history = ask(
+                chat_history=chat_history,
+                prompt=prompt,
+                tools=TOOLS_INFO
+            )
+
+            parse_n_print_response(response)
+            prompt = None
+
+        except KeyboardInterrupt:
+            print("\n   Exiting HackerX. See you later!")
+            break
+
+        except Exception as err:
+            print(f"\n   [!] An error occurred: {err}")
+            break
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        args = ' '.join(sys.argv[1:])
+        main(args)
+    else:
+        main()

--- a/agents/utils/agent_management.py
+++ b/agents/utils/agent_management.py
@@ -23,7 +23,7 @@ import requests
 DEFAULT_AI_MODEL: str
 SELECTED_VENDOR: str
 SELECTED_MODEL: str
-ALL_AI_PROVIDERS = ["gemini", "chatgpt", "ollama","openrouter"]  # FETCHED LATER FOR UPDATED LIST
+ALL_AI_PROVIDERS = ["gemini", "chatgpt", "ollama", "openrouter", "litellm"]  # FETCHED LATER FOR UPDATED LIST
 AI_MANAGEMENT_OPTIONS = ["/change model", "/reset to default model", "/list tools", "/help", "/exit", "/quit", "/bye"]
 console = Console(width=get_console_width())
 

--- a/requirements/pip-requirements.txt
+++ b/requirements/pip-requirements.txt
@@ -12,3 +12,4 @@ curl_cffi
 nodriver
 pyvirtualdisplay
 prompt_toolkit
+litellm

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,99 @@
+"""Tests for the LiteLLM provider in KaliGPT."""
+
+from unittest import mock
+from types import SimpleNamespace
+
+
+def _make_response(content="Hello", tool_calls=None):
+    msg = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+
+def _setup_provider():
+    """Import provider and set required globals."""
+    import agents.litellm_provider as provider
+    provider.LITELLM_MODEL = "anthropic/claude-sonnet-4-6"
+    provider.TOOLS_INFO = None
+    provider.TOOL_FUNCTION_MAP = {}
+    return provider
+
+
+class TestAsk:
+    """Verify ask() calls litellm.completion with correct params."""
+
+    def test_basic_completion(self):
+        fake_resp = _make_response("test output")
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(return_value=fake_resp)
+            provider = _setup_provider()
+
+            result, history = provider.ask(
+                "hello",
+                [{"role": "system", "content": "You are helpful."}],
+                tools=None,
+            )
+
+        assert result == "test output"
+        assert history[-1]["content"] == "test output"
+        assert history[-1]["role"] == "assistant"
+        assert litellm.completion.call_args[1]["drop_params"] is True
+
+    def test_model_forwarded(self):
+        fake_resp = _make_response("ok")
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(return_value=fake_resp)
+            provider = _setup_provider()
+            provider.LITELLM_MODEL = "bedrock/anthropic.claude-v2"
+
+            provider.ask("test", [{"role": "system", "content": "sys"}], tools=None)
+
+        assert litellm.completion.call_args[1]["model"] == "bedrock/anthropic.claude-v2"
+
+    def test_tools_forwarded(self):
+        fake_resp = _make_response("done")
+        fake_tools = [{"type": "function", "function": {"name": "test_tool"}}]
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(return_value=fake_resp)
+            provider = _setup_provider()
+
+            provider.ask("run tool", [{"role": "system", "content": "sys"}], tools=fake_tools)
+
+        call_kwargs = litellm.completion.call_args[1]
+        assert call_kwargs["tools"] == fake_tools
+        assert call_kwargs["tool_choice"] == "auto"
+
+    def test_no_tools_sends_none(self):
+        fake_resp = _make_response("done")
+
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(return_value=fake_resp)
+            provider = _setup_provider()
+
+            provider.ask("test", [{"role": "system", "content": "sys"}])
+
+        assert litellm.completion.call_args[1]["tool_choice"] == "none"
+
+    def test_error_returns_error_message(self):
+        with mock.patch.dict("sys.modules", {"litellm": mock.MagicMock()}):
+            import litellm
+            litellm.completion = mock.MagicMock(side_effect=Exception("auth failed"))
+            provider = _setup_provider()
+
+            result, _ = provider.ask("hello", [{"role": "system", "content": "sys"}], tools=None)
+
+        assert "auth failed" in result
+
+
+class TestAgentManagement:
+    """Verify litellm is registered as a provider."""
+
+    def test_litellm_in_providers_list(self):
+        from agents.utils.agent_management import ALL_AI_PROVIDERS
+        assert "litellm" in ALL_AI_PROVIDERS


### PR DESCRIPTION
## Summary

Adds a [LiteLLM](https://github.com/BerriAI/litellm) provider for KaliGPT, giving users access to 100+ LLM providers (AWS Bedrock, Azure OpenAI, Google Vertex AI, Mistral, Cohere, etc.) through a single unified SDK. Follows the existing standalone provider module pattern (same as `openrouter.py`).


## Changes

- `agents/litellm_provider.py` - New provider module following the `openrouter.py` pattern with `initialize_agent()`, `ask()` (with tool calling loop), and `main()` REPL. Uses `litellm.completion()` with `drop_params=True`.
- `agents/utils/agent_management.py` - Added `"litellm"` to `ALL_AI_PROVIDERS`
- `requirements/pip-requirements.txt` - Added `litellm`
- `tests/test_litellm_provider.py` - 6 unit tests covering completion, model forwarding, tool calling, error handling, and provider registration
- `README.md` - Added LiteLLM badge and CLI mode

## Tests

**1. Unit tests (6/6 passing):**
```
tests/test_litellm_provider.py::TestAsk::test_basic_completion PASSED
tests/test_litellm_provider.py::TestAsk::test_model_forwarded PASSED
tests/test_litellm_provider.py::TestAsk::test_tools_forwarded PASSED
tests/test_litellm_provider.py::TestAsk::test_no_tools_sends_none PASSED
tests/test_litellm_provider.py::TestAsk::test_error_returns_error_message PASSED
tests/test_litellm_provider.py::TestAgentManagement::test_litellm_in_providers_list PASSED

6 passed in 0.04s
```

**2. Live E2E against Anthropic via LiteLLM SDK:**
```python
import agents.litellm_provider as provider
provider.LITELLM_MODEL = 'anthropic/claude-sonnet-4-6'
result, _ = provider.ask(
    'What is 2+2? Answer in one word.',
    [{'role': 'system', 'content': 'You are a helpful assistant.'}],
    tools=None,
)
# Content: Four
```

## Example usage

Add litellm to `api.config.json`:
```json
{
    "default_provider": "litellm",
    "default_model": "anthropic/claude-sonnet-4-6",
    "litellm": {
        "api_key": "",
        "default_model": "anthropic/claude-sonnet-4-6",
        "models": []
    }
}
```

Set the provider's standard API key env var (e.g. `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`). LiteLLM accepts any model string dynamically. Full provider list: https://docs.litellm.ai/docs/providers

## Risk / Compatibility

- Additive only. Existing providers (Gemini, ChatGPT, Ollama, OpenRouter) are completely untouched.
- `drop_params=True` ensures cross-provider compatibility.
- No changes to core agent configs beyond adding `"litellm"` to the providers list.
