### PR TITLE
Add Requesty as an AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 ![Gemini](https://img.shields.io/badge/Gemini-8E75FF?style=for-the-badge&logo=googlegemini&logoColor=white)
 ![Ollama](https://img.shields.io/badge/Ollama-000000?style=for-the-badge&logo=ollama&logoColor=white)
 ![OpenRouter](https://img.shields.io/badge/OpenRouter-6566f1?style=for-the-badge&logo=openrouter&logoColor=white)
+![Requesty](https://img.shields.io/badge/Requesty-6D28D9?style=for-the-badge&logoColor=white)
 ![ChatGPT](https://img.shields.io/badge/ChatGPT-74aa9c?style=for-the-badge&logo=openai&logoColor=white)
 ![LiteLLM](https://img.shields.io/badge/🚅_LiteLLM-7C3AED?style=for-the-badge&logoColor=white)
 <!-- ![Claude](https://img.shields.io/badge/Claude-D97757?style=for-the-badge&logo=anthropic&logoColor=white) -->
@@ -83,6 +84,7 @@ MODES:
     -g  [--gemini]            =  use Gemini models (Online)
     -o  [--ollama]            =  use local models via Ollama (Offline,cloud:online )
     -or [--openrouter]        =  use OpenRouter models (Online)
+    -rq [--requesty]          =  use Requesty models (Online)
     -c  [--chatgpt]           =  use OpenAI models (Online)
     -ll [--litellm]           =  use 100+ providers via LiteLLM (Online)
     --web                     =  AIs official Web-Chat Opener (Online)

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -10,4 +10,5 @@ from .utils.tools import get_tools_info
 # After this change, run from the repo root:
 # python -m agents.gemini         ( For Gemini & Google Models )
 # python -m agents.openrouter     ( For OpenRouter hosted Models )
+# python -m agents.requesty       ( For Requesty hosted Models )
 # python -m agents.ollama         ( For Locally running Models via Ollama )

--- a/agents/requesty.py
+++ b/agents/requesty.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+
+# /agents/requesty.py
+# KaliGPT Requesty Agent
+# Updated: 24 feb 2026
+
+# Agent to use AI Models via Requesty OpenAI-compatible API
+
+import sys
+import json
+from openai import OpenAI
+
+from .utils.agent_configs import get_api_key, get_ai_specific_default_model
+from .utils.agent_management import AI_MANAGEMENT_OPTIONS, agent_management
+from .utils.parse_n_print_response import parse_n_print_response
+from .utils.tools import get_tools_info
+from .utils.openai_tool_adapter import openai_tool_adapter
+from .utils.prompts import WEB_BUG_BOUNTY_AGENT as SYSTEM_PROMPT
+
+# ----- Global Variables
+REQUESTY_API_KEY: str
+REQUESTY_MODEL: str
+TOOLS_INFO = None
+TOOL_FUNCTION_MAP: dict
+client: OpenAI
+
+def initialize_agent():
+  """Initializes the Tool configs (stored in global variables) like:
+        - API KEY
+        - AI Model to use for calls
+        - Tools information
+  """
+
+  global REQUESTY_API_KEY, REQUESTY_MODEL, TOOLS_INFO, TOOL_FUNCTION_MAP, client
+  try:
+    REQUESTY_API_KEY = get_api_key("requesty")
+    REQUESTY_MODEL = get_ai_specific_default_model("requesty")
+
+    if not REQUESTY_API_KEY or REQUESTY_API_KEY == "YOUR_REQUESTY_API_KEY":
+      print(f"[!] REQUESTY API Key not Found or not valid. exiting!")
+      sys.exit(0)
+
+    tools = get_tools_info()
+    TOOLS_INFO = [openai_tool_adapter(f) for f in tools]
+
+    # --- TOOL EXECUTION HELPER (Your Original Function) ---
+    TOOL_FUNCTION_MAP = {func.__name__: func for func in tools} if tools else {}
+
+    if not TOOLS_INFO:
+      print("[!] No external tools loaded.")
+
+    client = OpenAI(
+      base_url="https://router.requesty.ai/v1",
+      api_key=REQUESTY_API_KEY,
+    )
+
+  except Exception as e:
+    print(f"Failed to initialize Agent: {e}")
+    sys.exit(1)
+
+
+MAX_TURNS = 6   # user + assistant pairs
+
+def trim_history(history):
+    """ Trim chat history to keep within MAX_TURNS """
+    system = [m for m in history if m["role"] == "system"]
+    rest = [m for m in history if m["role"] != "system"]
+    return system + rest[-MAX_TURNS * 2:]
+
+
+def execute_tool_calls(tool_calls):
+    """Executes tools and returns a list of OpenAI-formatted 'tool' messages."""
+    tool_messages = []
+
+    for tool_call in tool_calls:
+        func_name = tool_call.function.name
+        call_id = tool_call.id
+
+        try:
+            func_args = json.loads(tool_call.function.arguments)
+            print(f"\n[HackerX Tool Use] name: {func_name}, args: {func_args}")
+        except Exception as e:
+            print(f"[!] Error parsing tool arguments: {e}")
+            func_args = {}
+
+        tool_fn = TOOL_FUNCTION_MAP.get(func_name)
+        if not tool_fn:
+            result = f"Error: Tool '{func_name}' not found"
+        else:
+            try:
+                result = tool_fn(**func_args)
+            except Exception as e:
+                result = f"Tool execution error: {e}"
+
+        # Correct OpenAI/Requesty Tool Message format
+        tool_messages.append({
+            "role": "tool",
+            "tool_call_id": call_id,
+            "name": func_name,
+            "content": str(result)
+        })
+
+    return tool_messages
+
+
+def ask(prompt, chat_history, tools=TOOLS_INFO):
+    """Ask Requesty model with recursive tool support and proper history."""
+
+    # Add the user message to the working set (don't append to persistent history yet)
+    messages = trim_history(chat_history) + [{"role": "user", "content": prompt}]
+
+    try:
+        # Step 1: Initial Request
+        completion = client.chat.completions.create(
+            model=REQUESTY_MODEL,
+            messages=messages,
+            tools=tools,
+            tool_choice="auto" if tools else "none"
+        )
+
+        response_msg = completion.choices[0].message
+
+        # Step 2: Tool Handling Loop (Handles nested/parallel calls)
+        while response_msg.tool_calls:
+            # Add the model's request to call tools to the history
+            messages.append(response_msg)
+
+            # Execute tools and get "tool" role messages
+            tool_results = execute_tool_calls(response_msg.tool_calls)
+            messages.extend(tool_results)
+
+            # Get the follow-up from the model
+            follow_up = client.chat.completions.create(
+                model=REQUESTY_MODEL,
+                messages=messages,
+                tools=tools
+            )
+            response_msg = follow_up.choices[0].message
+
+        # Step 3: Finalize History
+        final_text = response_msg.content or ""
+
+        # Update the actual history object for the next turn
+        chat_history.append({"role": "user", "content": prompt})
+        chat_history.append({"role": "assistant", "content": final_text})
+
+        return final_text, chat_history
+
+    except Exception as e:
+        error_msg = f"API/Logic Error: {str(e)}"
+        # print(f"[!] {error_msg}")
+
+        if "No endpoints found that support tool use" in error_msg:
+            completion = client.chat.completions.create(
+                model=REQUESTY_MODEL,
+                messages=messages,
+            )
+
+            response = completion.choices[0].message
+            chat_history.append({"role": "assistant", "content": response.content})
+
+            return response.content, chat_history
+
+        return error_msg, chat_history  # Ensures we always return a tuple
+
+
+def main(prompt=None):
+
+  initialize_agent()
+
+  # Initialize chat history with system prompt
+  chat_history: list = [{"role": "system", "content": SYSTEM_PROMPT}]
+
+  print(f"㉿ HackerX ( requesty/{REQUESTY_MODEL} )")
+
+  while True:
+    try:
+      if prompt is None:
+        prompt = input("\nYou ➤ ")
+
+      if prompt.lower().replace("-", " ").strip() in AI_MANAGEMENT_OPTIONS:
+        agent_management(prompt.lower().replace("-", " ").strip())
+        initialize_agent()
+        prompt = None
+        continue
+
+      response, chat_history = ask(
+        chat_history=chat_history,
+        prompt=prompt,
+        tools=TOOLS_INFO
+      )
+
+      # print(f"\nAgent ➤ ")
+      parse_n_print_response(response)
+      prompt = None
+
+    except KeyboardInterrupt:
+      print("\n   Exiting HackerX. See you later!")
+      break
+
+    except Exception as err:
+      print(f"\n   [!] An error occurred: {err}")
+      break
+
+
+if __name__ == "__main__":
+  if len(sys.argv) > 1:
+    args = ' '.join(sys.argv[1:])
+    main(args)
+  else:
+    main()

--- a/agents/utils/agent_configs.py
+++ b/agents/utils/agent_configs.py
@@ -39,6 +39,16 @@ def _load_config() -> Dict[str, Any]:
             "models": [
                 "z-ai/glm-4.5-air:free"
             ]
+        },
+        "requesty": {
+            "api_key": "YOUR_REQUESTY_API_KEY",
+            "default_model": "openai/gpt-4o-mini",
+            "models": [
+                "openai/gpt-4o-mini",
+                "openai/gpt-4o",
+                "anthropic/claude-sonnet-4-5",
+                "google/gemini-2.5-flash"
+            ]
         }
     }
 

--- a/agents/utils/agent_management.py
+++ b/agents/utils/agent_management.py
@@ -23,7 +23,7 @@ import requests
 DEFAULT_AI_MODEL: str
 SELECTED_VENDOR: str
 SELECTED_MODEL: str
-ALL_AI_PROVIDERS = ["gemini", "chatgpt", "ollama", "openrouter", "litellm"]  # FETCHED LATER FOR UPDATED LIST
+ALL_AI_PROVIDERS = ["gemini", "chatgpt", "ollama", "openrouter", "requesty", "litellm"]  # FETCHED LATER FOR UPDATED LIST
 AI_MANAGEMENT_OPTIONS = ["/change model", "/reset to default model", "/list tools", "/help", "/exit", "/quit", "/bye"]
 console = Console(width=get_console_width())
 

--- a/agents/utils/api.config.json
+++ b/agents/utils/api.config.json
@@ -67,6 +67,16 @@
             "x-ai/grok-3-mini",
             "x-ai/grok-3"
         ]
+    },
+    "requesty": {
+        "api_key": "YOUR_REQUESTY_API_KEY",
+        "default_model": "openai/gpt-4o-mini",
+        "models": [
+            "openai/gpt-4o-mini",
+            "openai/gpt-4o",
+            "anthropic/claude-sonnet-4-5",
+            "google/gemini-2.5-flash"
+        ]
     }
 }
 

--- a/agents/utils/web_launcher.json
+++ b/agents/utils/web_launcher.json
@@ -15,7 +15,8 @@
             "chatgpt": "https://chatgpt.com/g/g-xouSQobsE-kaligpt/?prompt=",
             "gemini": "https://gemini.google.com/",
             "claude": "https://claude.ai/new?q=",
-            "openrouter": "https://openrouter.ai/chat?prompt="
+            "openrouter": "https://openrouter.ai/chat?prompt=",
+            "requesty": "https://app.requesty.ai/router?prompt="
         }
     }
 }

--- a/installers/installer.arch.sh
+++ b/installers/installer.arch.sh
@@ -145,6 +145,7 @@ case "$MODE" in
   -g|--gemini)     st_opensearchapi; python3 -m agents.gemini "$@" ;;
   -o|--ollama)     st_opensearchapi; python3 -m agents.ollama "$@" ;;
   -or|--openrouter) st_opensearchapi; python3 -m agents.openrouter "$@" ;;
+  -rq|--requesty)  st_opensearchapi; python3 -m agents.requesty "$@" ;;
   -c|--chatgpt)    st_opensearchapi; python3 -m agents.chatgpt "$@" ;;
   --web)           python3 -m agents.web_launcher "$@" ;;
   --setup-keys)    python3 -m agents "$MODE" ;;
@@ -163,14 +164,16 @@ case "$MODE" in
     echo -e "\e[1;33mKaliGPT Provides:\e[0m
 1) Google Gemini Models   (Free/Paid, Online)  [ Requires API Key ]
 2) OpenRouter Models      (Free/Paid, Online)  [ Requires API Key ]
-3) Ollama                 (Free, Offline)      [ Local AI Models  ]
-4) OpenAI ChatGPT         (Paid, Online)       [ Requires API Key ]" ;;
+3) Requesty Models        (Paid, Online)       [ Requires API Key ]
+4) Ollama                 (Free, Offline)      [ Local AI Models  ]
+5) OpenAI ChatGPT         (Paid, Online)       [ Requires API Key ]" ;;
   -h|--help)
     echo -e "\e[1;32mKaliGPT v1.3 — by SudoHopeX\e[0m"
     echo -e "Usage: kaligpt [MODE] [Prompt]"
     echo -e "  -g  --gemini        Gemini models"
     echo -e "  -o  --ollama        Ollama (offline)"
     echo -e "  -or --openrouter    OpenRouter models"
+    echo -e "  -rq --requesty      Requesty models"
     echo -e "  -c  --chatgpt       OpenAI models"
     echo -e "  --web               Open AI web chat"
     echo -e "  --setup-keys        Configure API keys"

--- a/installers/installer.deb.sh
+++ b/installers/installer.deb.sh
@@ -173,6 +173,11 @@ case "$MODE" in
                 python3 -m agents.openrouter "$@"
                 ;;
 
+        -rq|--requesty)
+                st_opensearchapi
+                python3 -m agents.requesty "$@"
+                ;;
+
         -c|--chatgpt)
                 st_opensearchapi
                 python3 -m agents.chatgpt "$@"
@@ -195,6 +200,7 @@ case "$MODE" in
                 echo "    -g  [--gemini]            =  use Gemini Models (Online, text & code)"
                 echo "    -o  [--ollama]            =  use Ollama Models (Offline, text & code)"
                 echo "    -or [--openrouter]        =  use OpenRouter Models (Online, text & code)"
+                echo "    -rq [--requesty]          =  use Requesty Models (Online, text & code)"
                 echo "    -c  [--chatgpt]           =  use OpenAI Models (Online, text & code)"
                 echo "    --web                     =  AIs official Web-Chat Opener (Online)"
                 echo "    --setup-keys              =  setup API keys for online models"

--- a/installers/installer.termux.sh
+++ b/installers/installer.termux.sh
@@ -133,6 +133,11 @@ case "\$MODE" in
                   python3 -m agents.openrouter "\$@"
                   ;;
 
+        -rq|--requesty)
+                  start_opensearchapi
+                  python3 -m agents.requesty "\$@"
+                  ;;
+
         -c|--chatgpt)
                 start_opensearchapi
                 python3 -m agents.chatgpt "$@"
@@ -151,6 +156,7 @@ case "\$MODE" in
                 echo "    -g  [--gemini]            =  use Gemini Models (Online, text & code)"
                 echo "    -o  [--ollama]            =  use Ollama Cloud Models (Online, text & code)"
                 echo "    -or [--openrouter]        =  use OpenRouter Models (Online, text & code)"
+                echo "    -rq [--requesty]          =  use Requesty Models (Online, text & code)"
                 echo "    -c  [--chatgpt]           =  use OpenAI Models (Online, text & code)"
                 echo "    --web                     =  AIs official Web-Chat Opener (Online)"
                 echo "    --setup-keys              =  setup API keys for online models"


### PR DESCRIPTION
Adds Requesty (https://requesty.ai) as a first-class OpenAI-compatible provider, mirroring the existing OpenRouter agent.

- `agents/requesty.py`: new agent module, a faithful near-rename of `agents/openrouter.py` using the OpenAI SDK against `https://router.requesty.ai/v1`.
- `agents/utils/agent_configs.py` + `agents/utils/api.config.json`: `requesty` config block with verified Requesty model ids (`openai/gpt-4o-mini` default, `openai/gpt-4o`, `anthropic/claude-sonnet-4-5`, `google/gemini-2.5-flash`).
- `agents/utils/agent_management.py`, `web_launcher.json`, `__init__.py`: provider list + launch wiring (the `__main__.py` dispatch is dynamic, so `python -m agents.requesty` works automatically).
- Installers (`deb`/`arch`/`termux`) + `README.md`: `-rq|--requesty` option.

API keys: https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.